### PR TITLE
IAM-139 - Remove old links from Server Registration page

### DIFF
--- a/home.html
+++ b/home.html
@@ -69,14 +69,6 @@
      <tr><td></td><td nowrap>
       <a href=/smtp/>SMTP Exceptions</a></td></tr>
 
-     <tr><td></td><td nowrap>
-      <a href=/pubcookie/>Weblogin</a></td></tr>
-
-   <tr><td colspan=2 nowrap class=msg>Related pages</td></tr>
-
-     <tr><td></td><td nowrap>
-      <a href=http://www.washington.edu/computing/infra/>Infrastructure Services</a></td></tr>
-
 <!--
      <tr><td></td><td nowrap>
       <a href=http://www.washington.edu>UW home</a></td></tr>

--- a/index.html
+++ b/index.html
@@ -76,14 +76,6 @@
      <tr><td></td><td nowrap>
       <a href=/server-reg/smtp/>SMTP Exceptions</a></td></tr>
 
-     <tr><td></td><td nowrap>
-      <a href=/server-reg/pbc/>Weblogin</a></td></tr>
-
-   <tr><td colspan=2 nowrap class=msg>Related pages</td></tr>
-
-     <tr><td></td><td nowrap>
-      <a href=http://www.washington.edu/computing/infra/>Infrastructure Services</a></td></tr>
-
 </table>
 
 </td>


### PR DESCRIPTION
Looks like this pull request got left behind when server-reg was moved to github